### PR TITLE
'[FEAT]完善go-zero日志特性，添加xorm_sql日志，添加校验不重复发验证码逻辑'

### DIFF
--- a/core/etc/core-api.yaml
+++ b/core/etc/core-api.yaml
@@ -8,3 +8,11 @@ Mysql:
 
 Redis:
   Addr: localhost:6379
+
+Log:
+  ServiceName: core-api
+  Mode: file
+  Path: logs
+  Level: info
+  Encoding: json
+  KeepDays: 7

--- a/core/internal/logic/mail_code_send_register_logic.go
+++ b/core/internal/logic/mail_code_send_register_logic.go
@@ -38,6 +38,11 @@ func (l *MailCodeSendRegisterLogic) MailCodeSendRegister(req *types.MailCodeSend
 		err = errors.New("该邮箱已被注册")
 		return
 	}
+	// 校验验证码是否在有效期内
+	codeTTL, _ := l.svcCtx.RDB.TTL(l.ctx, req.Email).Result()
+	if codeTTL.Seconds() > 0 || codeTTL.Seconds() == -1 {
+		return nil, errors.New("the verify code has not expired")
+	}
 	// 获取验证码
 	code := helper.RandCode()
 	// 存储验证码

--- a/core/models/init.go
+++ b/core/models/init.go
@@ -2,10 +2,14 @@ package models
 
 import (
 	"cloud-disk/core/internal/config"
+	"log"
+	"os"
+
 	"github.com/go-redis/redis/v8"
 	_ "github.com/go-sql-driver/mysql"
-	"log"
+	"github.com/zeromicro/go-zero/core/logx"
 	"xorm.io/xorm"
+	xlog "xorm.io/xorm/log"
 )
 
 func Init(dataSource string) *xorm.Engine {
@@ -14,6 +18,14 @@ func Init(dataSource string) *xorm.Engine {
 		log.Printf("Xorm New Engine Error:%v", err)
 		return nil
 	}
+	xormLogFile, err := os.OpenFile("logs/xorm_sql.log", os.O_APPEND|os.O_WRONLY, 6)
+	if err != nil {
+		logx.Errorf("Open xorm_sql.log failed:%v", err)
+		return nil
+	}
+	engine.SetLogger(xlog.NewSimpleLogger(xormLogFile)) // 将日志重定向到文件中
+	engine.ShowSQL(true)                                // 打印出生成的SQL语句
+	engine.Logger().SetLevel(xlog.LOG_DEBUG)            // 打印调试及以上的信息
 	return engine
 }
 


### PR DESCRIPTION
1）添加验证码有效期内不重复发验证码，保障并发的性能
2）妥善利用go-zero的日志系统，完全可以把日志都重定向到文件当中去，xorm的sql语句在init.go那里配置一下xorm的sql日志